### PR TITLE
Add "Mastodon Redirector" userscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Forked from [tleb/awesome-mastodon](https://github.com/tleb/awesome-mastodon/edi
 * [NSFW Remover](https://greasyfork.org/fr/scripts/29228-mastodon-nsfw-remover) - Automatically display NSFW images.
 * [Customizable interface](https://openuserjs.org/scripts/bl00m/Mastodon_Customizable_Interface) - Move and resize columns on a grid.
 * [BirdSite](https://gitlab.com/pmorinerie/birdsite) - Browser extension for cross-posting Mastodon toots to Twitter.
+* [Mastodon Redirector](https://git.kaki87.net/KaKi87/userscripts/src/branch/master/mastodonRedirector/README.md) - Redirect any Mastodon app to your favourite one.
 
 ## Guides
 


### PR DESCRIPTION
Hello,

[Mastodon Redirector](https://git.kaki87.net/KaKi87/userscripts/src/branch/master/mastodonRedirector/README.md) is a userscript I created to redirect any profile or post URL from any Mastodon client & instance to the user's favourite one, allowing them to immediately interact with it.

Mastodon and Elk are currently supported, I intend to add support for others clients listed in this very list.

Thanks