### PR TITLE
Added Cloud Seeder

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ Comparison lists:
 
 ### Managed hosting
 
+- [Cloud Seeder](https://ipv6.rs/cloudseeder) - One click deployment and management solution for self hosting Mastodon.
 * [Masto.host](https://masto.host) - Fully managed Mastodon hosting.
 * [WebApe](https://webape.site/) - German-based Mastodon hosting service; also provides PeerTube, Nextcloud, Friendica, Matrix, Jitsi Meet, CryptPad and WordPress hosting
 * [toot.io](https://toot.io/mastodon_hosting.html) - Mastodon hosting service that serves HPC at University of Texas Austin, Association for Computing Machinery (ACM), amongst others


### PR DESCRIPTION
We would like to add Cloud Seeder by IPv6.rs to the awesome-mastodon list. Cloud Seeder by IPv6.rs can one-click deploy and manage a Mastodon instance, from IP address to access.

Thank you for the consideration.